### PR TITLE
OPS-6786 override vulnerable lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,11 @@
     "@aws-sdk/client-dynamodb": "3.x.x",
     "@aws-sdk/lib-dynamodb": "3.x.x"
   },
+  "pnpm": {
+    "overrides": {
+      "lodash": "4.18.1"
+    }
+  },
   "engines": {
     "node": ">=16"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  lodash: 4.18.1
+
 importers:
 
   .:
@@ -2993,8 +2996,8 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
@@ -6351,7 +6354,7 @@ snapshots:
       '@babel/helper-module-imports': 7.28.6
       '@babel/types': 7.29.0
       glob: 7.2.3
-      lodash: 4.17.23
+      lodash: 4.18.1
       require-package-name: 2.0.1
     transitivePeerDependencies:
       - supports-color
@@ -6393,7 +6396,7 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-module-imports': 7.28.6
       babel-plugin-syntax-jsx: 6.18.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       picomatch: 2.3.1
       styled-components: 6.3.8(react@19.2.4)
     transitivePeerDependencies:
@@ -8014,7 +8017,7 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
-  lodash@4.17.23: {}
+  lodash@4.18.1: {}
 
   log-update@6.1.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Fixes ticketed Dependabot alert #43 by forcing transitive lodash resolution to a patched release via pnpm overrides.
- Regenerates pnpm-lock.yaml so @shelf/babel-config transitive paths resolve lodash 4.18.1.

## Dependabot alerts fixed
- #43: lodash vulnerable to Prototype Pollution via array path bypass in _.unset and _.omit
  - Severity: medium
  - CVEs: none reported by Dependabot
  - CWE: CWE-1321
  - Vulnerable range: <= 4.17.23
  - Minimum patched version from alert: 4.18.0
  - Package upgraded: lodash
  - Before: 4.17.23
  - After: 4.18.1
  - Manifest: pnpm-lock.yaml
  - Introducer: @shelf/babel-config 3.0.0 via babel-plugin-lodash 3.3.4 and babel-plugin-styled-components 2.1.3
  - Upgrade path: @shelf/babel-config is already latest (3.0.0), so this uses a targeted pnpm override.

## Validation
- pnpm install --frozen-lockfile
- pnpm lint
- pnpm type-check
- pnpm test

## Notes
- Other open Dependabot alerts were intentionally left out because OPS-6786 only ticketed alert #43.
