### PR TITLE
OPS-6525 OPS-6526 Fix fast-xml-parser vulnerabilities

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@aws-sdk/xml-builder@3.972.4>fast-xml-parser': 5.3.5
+  '@aws-sdk/xml-builder@3.972.4>fast-xml-parser': 5.5.6
   eslint-config-next>eslint-import-resolver-typescript: 3.10.0
   eslint-plugin-barrel-files: 1.0.5
   lodash: 4.18.1
@@ -2542,8 +2542,11 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-xml-parser@5.3.5:
-    resolution: {integrity: sha512-JeaA2Vm9ffQKp9VjvfzObuMCjUYAp5WDYhRYL5LrBPY/jUDlUtOvDfot0vKSkB9tuX885BDHjtw4fZadD95wnA==}
+  fast-xml-builder@1.2.1:
+    resolution: {integrity: sha512-tPb5TTWfgfVx5BNSi2xV0eLr89POeXXn0dXIsCJ9m1narrWxeIyx6je9d7Rce/3NyXLbvuQmLkxq+RuxMWejvw==}
+
+  fast-xml-parser@5.5.6:
+    resolution: {integrity: sha512-3+fdZyBRVg29n4rXP0joHthhcHdPUHaIC16cuyyd1iLsuaO6Vea36MPrxgAzbZna8lhvZeRL8Bc9GP56/J9xEw==}
     hasBin: true
 
   fastq@1.20.1:
@@ -3411,6 +3414,10 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
+  path-expression-matcher@1.6.1:
+    resolution: {integrity: sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ==}
+    engines: {node: '>=14.0.0'}
+
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
@@ -3980,6 +3987,10 @@ packages:
     resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
+
   xml2js@0.6.2:
     resolution: {integrity: sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==}
     engines: {node: '>=4.0.0'}
@@ -4508,7 +4519,7 @@ snapshots:
   '@aws-sdk/xml-builder@3.972.4':
     dependencies:
       '@smithy/types': 4.12.0
-      fast-xml-parser: 5.3.5
+      fast-xml-parser: 5.5.6
       tslib: 2.8.1
 
   '@aws/dynamodb-auto-marshaller@0.7.1(aws-sdk@2.1693.0)':
@@ -7416,8 +7427,15 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-xml-parser@5.3.5:
+  fast-xml-builder@1.2.1:
     dependencies:
+      path-expression-matcher: 1.6.1
+      xml-naming: 0.1.0
+
+  fast-xml-parser@5.5.6:
+    dependencies:
+      fast-xml-builder: 1.2.1
+      path-expression-matcher: 1.6.1
       strnum: 2.1.2
 
   fastq@1.20.1:
@@ -8470,6 +8488,8 @@ snapshots:
 
   path-exists@4.0.0: {}
 
+  path-expression-matcher@1.6.1: {}
+
   path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
@@ -9124,6 +9144,8 @@ snapshots:
     dependencies:
       imurmurhash: 0.1.4
       signal-exit: 4.1.0
+
+  xml-naming@0.1.0: {}
 
   xml2js@0.6.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,7 +2,7 @@ packages:
   - .
 
 overrides:
-  '@aws-sdk/xml-builder@3.972.4>fast-xml-parser': 5.3.5
+  '@aws-sdk/xml-builder@3.972.4>fast-xml-parser': 5.5.6
   eslint-config-next>eslint-import-resolver-typescript: 3.10.0
   eslint-plugin-barrel-files: 1.0.5
   lodash: 4.18.1


### PR DESCRIPTION
## Summary

- raise the transitive `fast-xml-parser` override from `5.3.5` to the minimum safe `5.5.6`
- resolve both ticketed Dependabot alerts through the shared `@aws-sdk/xml-builder@3.972.4` dependency path

## Alerts

- #25 — GHSA-jmr7-xgp7-cmfj / CVE-2026-26278 (`>=5.0.0 <5.3.6`)
- #34 — GHSA-8gc5-j5rx-235r / CVE-2026-33036 (`>=5.0.0 <5.5.6`)

Ecosystem: npm  
Manifest: `pnpm-lock.yaml`  
Dependency: `fast-xml-parser` `5.3.5` → `5.5.6`

## Validation

- Node.js `v22.22.1`; pnpm `10.34.3`
- `pnpm install --frozen-lockfile`
- `pnpm why fast-xml-parser` (one resolved version: `5.5.6`)
- GHSA-jmr7-xgp7-cmfj entity-expansion PoC is blocked
- GHSA-8gc5-j5rx-235r numeric-entity expansion PoC is blocked
- `pnpm lint:ci`
- `pnpm type-check`
- `pnpm test`
- `pnpm build`
- `git diff --check`

Tickets: [OPS-6525](https://gemshelf.atlassian.net/browse/OPS-6525), [OPS-6526](https://gemshelf.atlassian.net/browse/OPS-6526)

[OPS-6525]: https://gemshelf.atlassian.net/browse/OPS-6525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OPS-6526]: https://gemshelf.atlassian.net/browse/OPS-6526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ