### PR TITLE
Pin pnpm 11 in aws-ddb-with-xray

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,5 +84,6 @@
       "oxfmt --no-error-on-unmatched-pattern",
       "eslint --fix"
     ]
-  }
+  },
+  "packageManager": "pnpm@11.18.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,3 +15,12 @@ overrides:
 ignoredBuiltDependencies:
   - aws-sdk
   - unrs-resolver
+nodeLinker: 'hoisted'
+trustPolicy: 'no-downgrade'
+blockExoticSubdeps: true
+minimumReleaseAge: 20160
+ignoreScripts: true
+minimumReleaseAgeExclude:
+  - '@shelf/*'
+trustPolicyExclude:
+  - 'semver'


### PR DESCRIPTION
## What
Add the `packageManager` field with `pnpm@11.18.0` to `package.json`.

Mirror the pnpm settings from `.npmrc` into `pnpm-workspace.yaml`. pnpm 11 reads settings only from `pnpm-workspace.yaml`. The mirror keeps the same install behavior, the supply-chain quarantine, and the trust policy.

## Why
We standardize all our repositories on pnpm 11. A pinned `packageManager` gives every developer and CI run the same pnpm version.

## How
- Small changes in `package.json` and `pnpm-workspace.yaml`.
- pnpm 11 keeps lockfile version `9.0`, so `pnpm-lock.yaml` stays unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
